### PR TITLE
shot in d'ARC

### DIFF
--- a/reverse_proxy/src/addresses.rs
+++ b/reverse_proxy/src/addresses.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 pub fn get_host_and_port(uri: &Uri) -> Option<String> {
     let host = match uri.host() {
-        Some(h) => h,
+        Some(h) => h.to_string(),
         _ => return None,
     };
 
@@ -26,13 +26,10 @@ pub fn get_host_and_port(uri: &Uri) -> Option<String> {
         }
     };
 
-    Some(host.to_string() + ":" + &port)
+    Some(host + ":" + &port)
 }
 
 pub fn get_host(req: &Request<Incoming>) -> Option<String> {
-    // more durable to say
-    // match req.version()
-
     // http2
     if let Some(host) = req.uri().host() {
         return Some(host.to_string());
@@ -83,8 +80,6 @@ fn add_addresses_to_map<'a>(
     addresses: &Vec<(String, String)>,
     is_dangerous: bool,
 ) -> Result<(), String> {
-    // get uri for source, get host
-
     // get uri for target, get host and port
     for (source_str, target_str) in addresses {
         let source_uri = match Uri::try_from(source_str) {
@@ -101,8 +96,6 @@ fn add_addresses_to_map<'a>(
             Ok(uri) => uri,
             Err(e) => return Err(e.to_string()),
         };
-
-        // remove path?
 
         url_map.insert(source_host.to_string(), (target_uri, is_dangerous));
     }

--- a/reverse_proxy/src/addresses.rs
+++ b/reverse_proxy/src/addresses.rs
@@ -1,62 +1,6 @@
 use config::Config;
-use hyper::body::Incoming;
-use hyper::header::HOST;
-use hyper::Request;
 use hyper::Uri;
 use std::collections::HashMap;
-
-pub fn get_host_and_port(uri: &Uri) -> Option<String> {
-    let host = match uri.host() {
-        Some(h) => h.to_string(),
-        _ => return None,
-    };
-
-    let port = match uri.port() {
-        Some(p) => p.to_string(),
-        _ => {
-            let scheme = match uri.scheme() {
-                Some(h) => h.as_str(),
-                _ => "http",
-            };
-
-            match scheme {
-                "https" => "443".to_string(),
-                _ => "80".to_string(),
-            }
-        }
-    };
-
-    Some(host + ":" + &port)
-}
-
-pub fn get_host(req: &Request<Incoming>) -> Option<String> {
-    // http2
-    if let Some(host) = req.uri().host() {
-        return Some(host.to_string());
-    };
-
-    // http 1
-    let host_header = match req.headers().get(HOST) {
-        Some(h) => h,
-        _ => return None,
-    };
-
-    let host_str = match host_header.to_str() {
-        Ok(hs) => hs,
-        _ => return None,
-    };
-
-    let host_as_uri = match Uri::try_from(host_str) {
-        Ok(hau) => hau,
-        _ => return None,
-    };
-
-    if let Some(host) = host_as_uri.host() {
-        return Some(host.to_string());
-    }
-
-    None
-}
 
 pub fn create_address_map(config: &Config) -> Result<HashMap<String, (Uri, bool)>, String> {
     // get host incoming

--- a/reverse_proxy/src/main.rs
+++ b/reverse_proxy/src/main.rs
@@ -50,6 +50,7 @@ async fn main() {
         Err(e) => return println!("{}", e),
     };
 
+    // https://docs.rs/native-tls/latest/native_tls/struct.TlsAcceptor.html#examples
     let tls_acceptor = Arc::new(native_acceptor);
 
     // bind tcp listeners

--- a/reverse_proxy/src/main.rs
+++ b/reverse_proxy/src/main.rs
@@ -45,10 +45,12 @@ async fn main() {
     };
 
     // create tls acceptor
-    let tls_acceptor = match native_tls::TlsAcceptor::builder(identity).build() {
+    let native_acceptor = match native_tls::TlsAcceptor::new(identity) {
         Ok(acceptor) => tokio_native_tls::TlsAcceptor::from(acceptor),
         Err(e) => return println!("{}", e),
     };
+
+    let tls_acceptor = Arc::new(native_acceptor);
 
     // bind tcp listeners
     let listener = match TcpListener::bind(config.host_and_port).await {

--- a/reverse_proxy/src/main.rs
+++ b/reverse_proxy/src/main.rs
@@ -45,13 +45,10 @@ async fn main() {
     };
 
     // create tls acceptor
-    let native_acceptor = match native_tls::TlsAcceptor::new(identity) {
+    let tls_acceptor = match native_tls::TlsAcceptor::new(identity) {
         Ok(acceptor) => tokio_native_tls::TlsAcceptor::from(acceptor),
         Err(e) => return println!("{}", e),
     };
-
-    // https://docs.rs/native-tls/latest/native_tls/struct.TlsAcceptor.html#examples
-    let tls_acceptor = Arc::new(native_acceptor);
 
     // bind tcp listeners
     let listener = match TcpListener::bind(config.host_and_port).await {
@@ -66,18 +63,19 @@ async fn main() {
             Err(e) => return println!("{}", e),
         };
 
-        // errors on tls handshake failure
-        let io = match tls_acceptor.clone().accept(socket).await {
-            Ok(s) => TokioIo::new(s),
-            Err(_e) => continue,
-        };
+        let acceptor = tls_acceptor.clone();
 
         let service = service::Svc {
             addresses: addresses_arc.clone(),
         };
 
         tokio::task::spawn(async move {
-            // log service error
+            // errors on tls handshake failure
+            let io = match acceptor.accept(socket).await {
+                Ok(s) => TokioIo::new(s),
+                Err(_e) => return,
+            };
+
             if let Err(_e) = Builder::new(TokioExecutor::new())
                 .serve_connection(io, service)
                 .await

--- a/reverse_proxy/src/requests.rs
+++ b/reverse_proxy/src/requests.rs
@@ -10,12 +10,39 @@ use hyper_util::rt::TokioIo;
 use native_tls::TlsConnector;
 use tokio::net::TcpStream;
 
-use crate::addresses;
-
 pub type BoxedResponse = Response<BoxBody<bytes::Bytes, hyper::Error>>;
 
 const UPSTREAM_HANDSHAKE_ERROR: &str = "upstream handshake failed";
 const FAILED_TO_PROCESS_REQUEST_ERROR: &str = "failed to process request";
+
+pub fn get_host(req: &Request<Incoming>) -> Option<String> {
+    // http2
+    if let Some(host) = req.uri().host() {
+        return Some(host.to_string());
+    };
+
+    // http 1
+    let host_header = match req.headers().get(header::HOST) {
+        Some(h) => h,
+        _ => return None,
+    };
+
+    let host_str = match host_header.to_str() {
+        Ok(hs) => hs,
+        _ => return None,
+    };
+
+    let host_as_uri = match Uri::try_from(host_str) {
+        Ok(hau) => hau,
+        _ => return None,
+    };
+
+    if let Some(host) = host_as_uri.host() {
+        return Some(host.to_string());
+    }
+
+    None
+}
 
 pub async fn get_response(
     req: Request<Incoming>,
@@ -49,11 +76,28 @@ pub fn create_fallback_response(
         )
 }
 
-fn get_host_and_authority<'a>(uri: &Uri) -> Result<(&str, String), &'a str> {
-    match (uri.host(), addresses::get_host_and_port(uri)) {
-        (Some(host), Some(host_and_port)) => Ok((host, host_and_port)),
-        _ => Err("failed to retrieve URI from upstream URI"),
-    }
+fn get_host_and_authority<'a>(uri: &Uri) -> Result<(String, String), &'a str> {
+    let host = match uri.host() {
+        Some(h) => h.to_string(),
+        _ => return Err("failed to retrieve URI from upstream URI"),
+    };
+
+    let port = match uri.port() {
+        Some(p) => p.to_string(),
+        _ => {
+            let scheme = match uri.scheme() {
+                Some(h) => h.as_str(),
+                _ => "http",
+            };
+
+            match scheme {
+                "https" => "443".to_string(),
+                _ => "80".to_string(),
+            }
+        }
+    };
+
+    Ok((host.clone(), host + ":" + &port))
 }
 
 async fn create_tcp_stream<'a>(addr: &str) -> Result<TokioIo<TcpStream>, &'a str> {

--- a/reverse_proxy/src/service.rs
+++ b/reverse_proxy/src/service.rs
@@ -8,7 +8,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::addresses;
 use crate::requests;
 
 const URI_FROM_REQUEST_ERROR: &str = "unable to parse upstream URI from request";
@@ -25,7 +24,7 @@ impl Service<Request<Incoming>> for Svc {
 
     fn call(&self, mut req: Request<Incoming>) -> Self::Future {
         // get origin host from request
-        let host = match addresses::get_host(&req) {
+        let host = match requests::get_host(&req) {
             Some(uri) => uri,
             _ => {
                 return Box::pin(async {

--- a/reverse_proxy/src/service.rs
+++ b/reverse_proxy/src/service.rs
@@ -1,3 +1,5 @@
+use http::uri::Scheme;
+use http::Uri;
 use hyper::body::Incoming;
 use hyper::service::Service;
 use hyper::{Request, StatusCode};
@@ -13,7 +15,7 @@ const URI_FROM_REQUEST_ERROR: &str = "unable to parse upstream URI from request"
 const UPSTREAM_URI_ERROR: &str = "falied to update request with upstream URI";
 
 pub struct Svc {
-    pub addresses: Arc<HashMap<String, (http::Uri, bool)>>,
+    pub addresses: Arc<HashMap<String, (Uri, bool)>>,
 }
 
 impl Service<Request<Incoming>> for Svc {
@@ -66,23 +68,21 @@ impl Service<Request<Incoming>> for Svc {
 
 fn update_request_with_dest_uri(
     req: &mut Request<Incoming>,
-    target_uri: http::Uri,
+    target_uri: Uri,
 ) -> Result<(), String> {
-    let target_path_opt = req.uri().path_and_query();
     let mut dest_parts = target_uri.into_parts();
 
-    // start with nothing
+    if let None = dest_parts.scheme {
+        dest_parts.scheme = Some(Scheme::HTTP);
+    }
+
+    // start with no path
     dest_parts.path_and_query = None;
-    if let Some(path_and_query) = target_path_opt {
+    if let Some(path_and_query) = req.uri().path_and_query() {
         dest_parts.path_and_query = Some(path_and_query.clone());
     }
 
-    // dest_parts.path_and_query = target_path_opt.clone();
-    if let None = dest_parts.scheme {
-        dest_parts.scheme = Some(http::uri::Scheme::HTTP);
-    }
-
-    *req.uri_mut() = match http::Uri::from_parts(dest_parts) {
+    *req.uri_mut() = match Uri::from_parts(dest_parts) {
         Ok(u) => u,
         Err(e) => return Err(e.to_string()),
     };


### PR DESCRIPTION
CHALLENGE:
Server eventually (hours to days after launch) hang indefinitely until a client times out. Systemd registers it as not having failed, no error is logged despite error endpoints printing statements.

POSSIBLE SOLUTION:
Looked up documentation including ARCing a tls_acceptor and cloning the arc in a loop. And I think that was close. But it still failed

Other documentation revealed an example (lost to me where atm, maybe i dreamt it?) that pointed to a socket being accepted before it was needed.

Theres some physical compute time between accepting the socket and "moving" it to a task.

As There seems to be an issue with `tsl_acceptor` clones accepting a socket connection _outside_ a spawnd tokio task.


Previously a server would error eventually (hours days?) using the following
```rs
// cloned and accepted outside of spawned task
let io = match tls_acceptor.clone().accept(socket).await {
  Ok(s) => TokioIo::new(s),
  Err(_e) => continue,
};
```

After the following changes to `main.rs`:

```rs
tokio::task::spawn(async move {
  // errors on tls handshake failure
  let io = match acceptor.accept(socket).await {
    Ok(s) => TokioIo::new(s),
    Err(_e) => return,
  };
...
```

Sever behavior has stabalized (at least within the span of days now).
